### PR TITLE
Change "muncodes" setting from string-array to simple string

### DIFF
--- a/src/geosearch_dk/searchbox.py
+++ b/src/geosearch_dk/searchbox.py
@@ -92,7 +92,8 @@ class SearchBox(QFrame, FORM_CLASS):
             'resources': RESOURCES, #str(s.value(k + "/resources", RESOURCES, type=str)),
             'maxresults': s.value(k + "/maxresults", 25, type=int),
             'callback': str(s.value(k + "/callback", "callback", type=str)),
-            'muncodes': s.value(k + "/muncodes", [])
+            'muncodes': str(s.value(k + "/muncodes", "", type=str))
+
         }
 
     def updateconfig(self):
@@ -128,7 +129,7 @@ class SearchBox(QFrame, FORM_CLASS):
             login=self.config['username'],
             password=self.config['password'],
             callback=self.config['callback'],
-            area=','.join(['muncode0'+str(k) for k in self.config['muncodes']])
+            area=self.config['muncodes']
         )
 
         url += searchterm
@@ -270,7 +271,7 @@ class SearchBox(QFrame, FORM_CLASS):
         dlg = settingsdialog.SettingsDialog(self.qgisIface)
         dlg.loginLineEdit.setText(self.config['username'])
         dlg.passwordLineEdit.setText(self.config['password'])
-        dlg.kommunekoderLineEdit.setText(','.join(map(str, self.config['muncodes'])))
+        dlg.kommunekoderLineEdit.setText(self.config['muncodes'].replace("muncode0",""))
         for dic in RESOURCESdic.values():
             cb = getattr(dlg,dic['checkbox'])
             if dic['id'] in self.config['resources']:
@@ -286,7 +287,8 @@ class SearchBox(QFrame, FORM_CLASS):
             # save settings
             self.config['username'] = str(dlg.loginLineEdit.text())
             self.config['password'] = str(dlg.passwordLineEdit.text())
-            self.config['muncodes'] = [int(k) for k in dlg.kommunekoderLineEdit.text().split(',') if not k.strip() == '']
+            self.config['muncodes'] = str(dlg.kommunekoderLineEdit.text())
+            self.config['muncodes'] = 'muncode0' + self.config['muncodes'].replace(",",",muncode0") if self.config['muncodes'] != '' else ''
             resources_list = []
             for dic in sorted(RESOURCESdic.values()):
                 cb = getattr(dlg,dic['checkbox'])

--- a/src/geosearch_dk/searchbox.py
+++ b/src/geosearch_dk/searchbox.py
@@ -84,16 +84,24 @@ class SearchBox(QFrame, FORM_CLASS):
         self.searchEdit.setFocus()
 
     def readconfig(self):
+
         s = QSettings()
         k = __package__
+        # Butt ugly hack to change muncode setting from old to new format
+        x = str(s.value(k + "/muncodes", "", type=str))
+        x = x.replace("[","")
+        x = x.replace("]","")
+        x = x.replace("u'","muncode0")
+        x = x.replace("'","")
+        x = x.replace(" ","")
+        # Hack finished (Some regexp guru could probably do a one-liner, but i'm too bloody tired)
         self.config = {
             'username': str(s.value(k + "/username", "", type=str)),
             'password': str(s.value(k + "/password", "", type=str)),
             'resources': RESOURCES, #str(s.value(k + "/resources", RESOURCES, type=str)),
             'maxresults': s.value(k + "/maxresults", 25, type=int),
             'callback': str(s.value(k + "/callback", "callback", type=str)),
-            'muncodes': str(s.value(k + "/muncodes", "", type=str))
-
+            'muncodes': x
         }
 
     def updateconfig(self):

--- a/src/geosearch_dk/settingsdialog.py
+++ b/src/geosearch_dk/settingsdialog.py
@@ -25,8 +25,8 @@ from PyQt4 import uic
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'ui_settings.ui'))
 
-MUNCODE_REGEX = '[0-9,]*'
 
+MUNCODE_REGEX = '[0-9]{3}(,[0-9]{3})*'
 
 class SettingsDialog (QDialog, FORM_CLASS):
     def __init__(self, qgisIface):


### PR DESCRIPTION
The use of a string-array for setting "muncodes" is the cause of some trouble ( #24 ) in septima - master branch.

This pull request remedy this by changing the "muncodes" setting to a simple string. 

This is **not** tested on a linux- or mac- based pc, but **works** on Windows - both with settings in registry and settings saved in a ini-file (-configpath parametr used).

Further, the patch will convert existing settings to the new format (using a butt ugly hack)