### PR TITLE
Fix kf redirect

### DIFF
--- a/src/geosearch_dk/autosuggest.py
+++ b/src/geosearch_dk/autosuggest.py
@@ -167,8 +167,13 @@ class AutoSuggest(QObject):
             qurl = self.geturl_func( term )
             if qurl:
                 # TODO: Cancel existing requests: http://qt-project.org/forums/viewthread/18073
-                self.networkManager.get(QNetworkRequest( qurl ))      #QUrl(url)))
-
+                r = QNetworkRequest(qurl)
+                r.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
+                r.setAttribute(
+                    QNetworkRequest.RedirectPolicyAttribute,
+                    QNetworkRequest.RedirectPolicy.NoLessSafeRedirectPolicy,
+                )
+                self.networkManager.get(r)  # QUrl(url)))
 
     def handleNetworkData(self, networkReply):
         url = networkReply.url()

--- a/src/geosearch_dk/config/settings.py
+++ b/src/geosearch_dk/config/settings.py
@@ -10,7 +10,7 @@ class Settings(SettingManager):
     def __init__(self):
         SettingManager.__init__(self, 'Geosearch DK')
 
-        self.baseurl = "http://kortforsyningen.kms.dk/Geosearch?service=GEO&resources={resources}&area={area}&limit={limit}&token={token}&callback={callback}&search="
+        self.baseurl = "https://api.dataforsyningen.dk/Geosearch?service=GEO&resources={resources}&area={area}&limit={limit}&token={token}&callback={callback}&search="
 
         # The order here is the order results are displayed in
         self.resources = {

--- a/src/geosearch_dk/metadata.txt
+++ b/src/geosearch_dk/metadata.txt
@@ -9,7 +9,7 @@ qgisMinimumVersion=3.0
 qgisMaximumVersion=3.98
 description=Search and zoom to named places in Denmark
 about= Uses Kortforsyningen services for searching Danish addresses, road names, place names, land registry and a lot more. This plugin is developed by Septima.
-version=1.1.0
+version=1.2.0
 author=Asger Skovbo Petersen, Septima
 email=asger@septima.dk
 
@@ -18,7 +18,8 @@ email=asger@septima.dk
 # Optional items:
 
 # Uncomment the following line and add your changelog entries:
-changelog=2019-04-10 1.1.0 Use Kortforsyningen token instead of username/password. Move plugin settings to main QGIS Settings dialog.  
+changelog=2020-12-21 1.2.0 Use dataforsyningen.dk instead of kortforsyningen.dk. Use native QGIS http fetcher to make requests show up in the debugging tools.  
+    2019-04-10 1.1.0 Use Kortforsyningen token instead of username/password. Move plugin settings to main QGIS Settings dialog.  
     2019-01-06 1.0.4 Fix problem with multigeometries (Funded by Roskilde Kommune)
     2018-06-14 1.0.3 Removed python future
     2018-03-01 1.0.2 Avoid crash when QSettings().value("locale/userLocale") returns a NULL QVariant

--- a/src/geosearch_dk/searchbox.py
+++ b/src/geosearch_dk/searchbox.py
@@ -168,9 +168,7 @@ class SearchBox(QFrame, FORM_CLASS):
 
     def setupCrsTransform(self):
         if QgsCoordinateReferenceSystem is not None:
-            srcCrs = QgsCoordinateReferenceSystem(
-                25832, QgsCoordinateReferenceSystem.EpsgCrsId
-            )
+            srcCrs = QgsCoordinateReferenceSystem.fromEpsgId(25832)
             dstCrs = qgisutils.getCurrentCrs(self.qgisIface)
             self.crsTransform = QgsCoordinateTransform(srcCrs, dstCrs, QgsProject.instance())
 


### PR DESCRIPTION
- Now uses QGIS native QgsNetworkContentFetcher, which is supposed to automatically handle redirects.
- Uses `api.dataforsyningen.dk` instead of `kortforsyningen.kmd.dk`