### PR TITLE
Add missing license headers & minor corrections

### DIFF
--- a/src/geosearch_dk/Makefile
+++ b/src/geosearch_dk/Makefile
@@ -1,7 +1,7 @@
 #/***************************************************************************
 # geosearch_dk
 #
-# Nem adgang til kortforsyningens geosearch service
+# Nem adgang til SDFI's Gsearch-service
 #							 -------------------
 #		begin				: 2015-05-01
 #		git sha				: $Format:%H$
@@ -10,12 +10,12 @@
 # ***************************************************************************/
 #
 #/***************************************************************************
-# *																		 *
+# *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU General Public License as published by  *
-# *   the Free Software Foundation; either version 2 of the License, or	 *
-# *   (at your option) any later version.								   *
-# *																		 *
+# *   the Free Software Foundation; either version 3 of the License, or     *
+# *   (at your option) any later version.                                   *
+# *                                                                         *
 # ***************************************************************************/
 
 #################################################

--- a/src/geosearch_dk/__init__.py
+++ b/src/geosearch_dk/__init__.py
@@ -2,7 +2,7 @@
 """
 /***************************************************************************
 Name                 : geosearch_dk
-Description          : Search suggestions in QGIS using GST's geosearch service
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
 Date                 : 24-05-2013
 copyright            : (C) 2013 by Septima
 author               : asger@septima.dk

--- a/src/geosearch_dk/config/__init__.py
+++ b/src/geosearch_dk/config/__init__.py
@@ -1,4 +1,22 @@
 # -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+Name                 : geosearch_dk
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
+Date                 : 09-04-2019
+copyright            : (C) 2019 by Septima
+author               : asger@septima.dk
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
 from .options_factory import OptionsFactory
 from .settings import Settings
 from .settings_dialog import ConfigDialog

--- a/src/geosearch_dk/config/options_factory.py
+++ b/src/geosearch_dk/config/options_factory.py
@@ -1,3 +1,22 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+Name                 : geosearch_dk
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
+Date                 : 09-04-2019
+copyright            : (C) 2019 by Septima
+author               : asger@septima.dk
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
 import os
 from qgis.gui import (QgsOptionsWidgetFactory)
 from qgis.core import QgsApplication

--- a/src/geosearch_dk/config/settings.py
+++ b/src/geosearch_dk/config/settings.py
@@ -1,4 +1,22 @@
 # -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+Name                 : geosearch_dk
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
+Date                 : 09-04-2019
+copyright            : (C) 2019 by Septima
+author               : asger@septima.dk
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
 import os
 
 from qgis.PyQt import QtCore

--- a/src/geosearch_dk/config/settings_dialog.py
+++ b/src/geosearch_dk/config/settings_dialog.py
@@ -1,4 +1,22 @@
 # -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+Name                 : geosearch_dk
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
+Date                 : 09-04-2019
+copyright            : (C) 2019 by Septima
+author               : asger@septima.dk
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
 import os
 from PyQt5 import QtGui, uic
 from PyQt5.QtWidgets import QFileDialog

--- a/src/geosearch_dk/gsearchfetcher.py
+++ b/src/geosearch_dk/gsearchfetcher.py
@@ -1,3 +1,21 @@
+"""
+/***************************************************************************
+Name                 : geosearch_dk
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
+Date                 : 13-06-2023
+copyright            : (C) 2023 by Septima
+author               : klavs@septima.dk
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
 import re
 import json
 

--- a/src/geosearch_dk/help/source/conf.py
+++ b/src/geosearch_dk/help/source/conf.py
@@ -1,4 +1,22 @@
 # -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+Name                 : geosearch_dk
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
+Date                 : 24-05-2013
+copyright            : (C) 2013 by Septima
+author               : asger@septima.dk
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
 #
 # septimaaddresssearch documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 12 17:11:03 2012.

--- a/src/geosearch_dk/multigetter.py
+++ b/src/geosearch_dk/multigetter.py
@@ -1,3 +1,22 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+Name                 : geosearch_dk
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
+Date                 : 13-06-2023
+copyright            : (C) 2023 by Septima
+author               : klavs@septima.dk
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
 import json
 import uuid
 

--- a/src/geosearch_dk/qgisutils.py
+++ b/src/geosearch_dk/qgisutils.py
@@ -2,7 +2,7 @@
 """
 /***************************************************************************
 Name                 : geosearch_dk
-Description          : Search suggestions in QGIS using GST's geosearch service
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
 Date                 : 24-05-2013
 copyright            : (C) 2013 by Septima
 author               : asger@septima.dk

--- a/src/geosearch_dk/searchbox.py
+++ b/src/geosearch_dk/searchbox.py
@@ -2,7 +2,7 @@
 """
 /***************************************************************************
 Name                 : geosearch_dk
-Description          : Search suggestions in QGIS using GST's geosearch service
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
 Date                 : 24-05-2013
 copyright            : (C) 2013 by Septima
 author               : asger@septima.dk

--- a/src/geosearch_dk/septimageosearch.py
+++ b/src/geosearch_dk/septimageosearch.py
@@ -2,7 +2,7 @@
 """
 /***************************************************************************
 Name                 : geosearch_dk
-Description          : Search suggestions in QGIS using GST's geosearch service
+Description          : Search suggestions in QGIS using SDFI's Gsearch service
 Date                 : 24-05-2013
 copyright            : (C) 2013 by Septima
 author               : asger@septima.dk


### PR DESCRIPTION
* add license and encoding header to all Python source files which are not part of the QGIS Setting Manager code (ie. outside config/qgissettingmanager/)
* set header date and author according to git logs

* replace every mention of deprecated geosearch service with "SDFI's Gsearch"
* bump Makefile license from GPL2.0-or-later to GPL3.0-or-later to be in sync with rest of code
* fix white space mess in Makefile license header