### PR TITLE
Elaborate on copyright & licenses and do some copy-editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,34 @@
 Geosearch DK
 ==============
 
-QGIS plugin med en søgebox, som tillader brugeren lynhurtigt at zoome til navngivne steder i Danmark - fx adresser, stednavne, kommuner.
+QGIS-plugin der tilføjer en søgeboks der anvender offentlige data, som tillader brugeren lynhurtigt at zoome til navngivne steder i Danmark - f.eks. adresser, stednavne, kommuner.
 
-Pluginet er udviklet af [Septima](http://www.septima.dk), som har frigivet det under Open Source licensen [GPL3](http://www.gnu.org/licenses/gpl.html).
+Pluginet er udviklet af [Septima](http://www.septima.dk) og stilles frit og gratis til rådighed for QGIS-brugere under GNU General Public License v3.0, se nærmere i afsnittet [Ophavsret og videredistribution](#ophavsret-og-videredistribution).
 
 OBS - Er dit plugin stoppet med at virke efter 31. august 2023?
 --------------
-Styrelsen for Dataforsyning og Infrastruktur (SDFI) har pr. 31. august 2023 nedlagt API-tjenesten Geosearch. Denne tjeneste er erstattet af den nye tjeneste Gsearch. Du skal opdatere til den nye version af pluginet (version 2.0.0) for at dit plugin bruger Gsearch - **og derfor virker efter 31. august 2023**. Du henter den nye version fra QGIS' plugin repository - dette er lettest at hente direkte fra QGIS. Læs mere om dette under afsnittet 'Opdatering af pluginet'.
+[Styrelsen for Dataforsyning og Infrastruktur (SDFI)](https://sdfi.dk/) har pr. 31. august 2023 nedlagt den hidtil anvendte API-tjeneste Geosearch, og erstattet den med den nye tjeneste [Gsearch](https://docs.dataforsyningen.dk/#gsearch-dokumentation). Du skal opdatere til den nye version af pluginet (version 2.0.0) for at dit plugin bruger Gsearch - **og derfor virker efter 31. august 2023**. Du henter den nye version fra QGIS' plugin repository - dette er lettest at hente direkte fra QGIS. Læs mere om dette i afsnittet [Opdatering af pluginet](#opdatering-af-pluginet).
+
+Læs nyheden om ændringen i dette plugin [på Septimas hjemmeside](https://septima.dk/nyheder/Ny-version-GeosearchDKplugin) eller detaljer om Gsearch i [projektets koderepository](https://github.com/SDFIdk/gsearch).
 
 Installation af pluginet
 --------------
-Pluginet er tilgængeligt fra QGIS' officielle plugin repository, dermed finder QGIS selv en kompatibel version af pluginet.
+Pluginet er tilgængeligt fra QGIS' officielle plugin repository, dermed finder en installation af QGIS selv en kompatibel version af pluginet.
 
 Det letteste er at installere pluginet via QGIS. Dette gør du således:
    * Under menuen 'Plugins', vælg 'Administrér og Installér Plugins...' (I den engelske version af QGIS hedder denne menu 'Manage and Install Plugins...')
-   * I Plugins-dialogen, søg efter 'GeosearchDK'
-   * Vælg 'GeosearchDK' i listen (så denne bliver markeret med blå)
+   * I Plugins-dialogen, søg efter 'Geosearch DK'
+   * Vælg 'Geosearch DK' i listen (så denne bliver markeret med blå)
    * Klik på 'Installér Plugin'. Derefter installeres pluginet.
 
 ![Install-geosearchdk](https://github.com/Septima/qgis-geosearch/assets/16276034/3b5a5d6c-70fe-49a0-9372-1fdb18585831)
 
 
-Pluginet installerer en søgebox, der som udgangspunkt lægger sig oven for kortvinduet. Panelet kan flyttes, så det fx ligger oven for lagpanelet i stedet. På denne placering fylder det ikke så meget, men er stadig let tilgængeligt.
+Pluginet installerer et QGIS-panel med en søgeboks, der som udgangspunkt lægger sig oven for kortvinduet. Panelet kan flyttes, så det f.eks. ligger oven for lagpanelet i stedet. På denne placering fylder det ikke så meget, men er stadig let tilgængeligt.
 
-Pluginet distribueres med et fungerende token til Dataforsyningen. Det er muligt at angive sit eget token under pluginets indstillinger.
+Hvis man trykker på krydset i Geosearch DK-panelet bliver det deaktiveret og forsvinder helt fra visningen, men kan nemt genaktiveres ved at sætte flueben ved det under menupunktet Visning->Paneler (på engelsk View->Panels).
+
+Pluginet distribueres med et fungerende token til Dataforsyningen. Det er muligt at angive sit eget token (dvs. [autentificere som en bestemt bruger](https://dataforsyningen.dk/news/3808)) under pluginets indstillinger, som findes ved at gå til menupunktet Indstillinger->Indstillinger->Geosearch DK (engelsk Settings->Options) eller bruge genvejen via skruenøgle-ikonet i panelet.
 
 Opdatering af pluginet
 --------------
@@ -41,13 +45,13 @@ Vil du selv opdatere dit plugin, så gør således:
 
 Indstillinger
 -----------------
-Du kan lave en række indstillinger i pluginets indstillingsfane, som du kan åbne ved at klikke på skruenøgle-ikonet:
+Du kan lave en række indstillinger i pluginets indstillingsfane, som du kan åbne ved at klikke på skruenøgle-ikonet (eller gå til menupunktet Indstillinger->Indstillinger->Geosearch DK (engelsk Settings->Options)):
 ![geosearchdk-opensettings](https://github.com/Septima/qgis-geosearch/assets/16276034/3f56d335-7397-4779-b7b0-c39e811fd9eb)
 
-Følgende instilllinger kan foretages i pluginets indstillingsdialog:
-- Token til Dataforsyningen (Opret token [her]([https://dataforsyningen.dk/user#token](https://dataforsyningen.dk/)) - sørg for at du er logget ind øverst til højre og opret derefter et token under "Administrer token til webservices og API'er"
+Følgende indstillinger kan foretages i pluginets indstillingsdialog:
+- Token til Dataforsyningen (Opret token [her](https://dataforsyningen.dk/user#token)) - sørg for at du er logget ind øverst til højre og opret derefter et token under "Administrer token til webservices og API'er"
 - Kommunefilter. Indtast et eller flere kommunenumre adskilt af komma. Der vises nu kun søgeresultater fra de listede kommuner.
-- Typefilter. Vis kun søgeresultater af bestemte typer, fx adresser, matrikelnumre, stednavne etc.
+- Typefilter. Vis kun søgeresultater af bestemte typer, f.eks. adresser, matrikelnumre, stednavne etc.
 
 ![geosearchsettings](https://github.com/Septima/qgis-geosearch/assets/16276034/ffcfe419-38af-4ed1-80f8-bc2264919fb0)
 
@@ -58,4 +62,12 @@ Der er allerede en række forslag til forbedringer i projektets [Issuetracker](.
 
 Har du en idé til en forbedring eller har du måske opdaget en bug i pluginet, så vil Septima med glæde tilbyde sin bistand.
 
-Du kan registrere din idé eller bug i projektets [Issuetracker](../../issues). Her kan du også se eksistrende registreringer af idéer og bugs.
+Du kan registrere din idé eller bug i projektets [Issuetracker](../../issues). Her kan du også se eksisterende registreringer af idéer og bugs.
+
+Ophavsret og videredistribution
+-------------------------------
+Pluginet er udviklet af [Septima](http://www.septima.dk), som er primær ophavsretsindehaver men som har givet tilladelse til distribution under betingelserne i Open Source/Fri Software-licensen [GNU General Public License v3.0](http://www.gnu.org/licenses/gpl.html) eller senere ([GPL3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later)).
+
+Det indeholder dog også kode fra projektet [QGIS Setting Manager](https://opengisch.github.io/qgis_setting_manager/) (under stien `src/geosearch_dk/config/qgissettingmanager/`) som kan distribueres under licensen [GNU General Public License v2.0](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html) eller senere ([GPL2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later)).
+
+Ophavsretsinformation og licensbetingelser for en konkret fil kan altid ses i toppen af den enkelte fil.


### PR DESCRIPTION
Updates to README motivated by outcome of discussion in #53 and miscellaneous additions and corrections after using it. Feel free to modify to fit Septima preferences to wording/terminology.

* add copyright section with precise information about Septima as copyright owner and redistibution under GPL3.0-or-later as dictated by source headers
* mention the QGIS Setting Manager code and its different license
* add a friendly "freely available for no cost" text in intro with reference to copyright section

* add links to SDFI, Gsearch docs./repo, Septima news about the service change and help page for Dataforsyningen token
* add help paragraph for recovering the panel if closed inadvertently
* make it clear that search box is a QGIS panel
* mention menu path to Indstillinger/Settings
* correct erroneous search term during installation

* fix a b0rked link
* misc. typo fixes
* box -> boks (not in Retskrivningsordbogen)
* fx -> f.eks. (is in Retskrivningsordbogen, so mostly a personal preference)