### PR TITLE
gzip server bug workaround

### DIFF
--- a/src/geosearch_dk/multigetter.py
+++ b/src/geosearch_dk/multigetter.py
@@ -37,6 +37,7 @@ class MultiGetter(QObject):
         self.get_id = str(uuid.uuid4())
         for key, url in urls.items():
             request = QNetworkRequest( QUrl(url) )
+            request.setRawHeader(b"Accept-Encoding", b"identity")
             networkReply = self.networkManager.get(request) 
             self.replies[key] = networkReply
             self.results[key] = None


### PR DESCRIPTION
`api.dataforsyningen.dk` gateway has a bug where the gzip data is malformed. Browsers might accept this, but QGIS does not. We don't know when the gateway will be fixed.

This workaround performs requests with a HTTP header that disables gzip output in the replies. As requests are usually very small the extra data from uncompressed replies would be negligible.